### PR TITLE
fix: docker build error 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu
 MAINTAINER lifeforce "lifeforce@foxmail.com"
 
 # 安装JDK与nginx
+RUN echo 'deb http://cn.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse' >>/etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install openjdk-7-jre -y
 RUN apt-get install openjdk-7-jdk -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 # 签名
 MAINTAINER lifeforce "lifeforce@foxmail.com"
 


### PR DESCRIPTION
fix: Package openjdk-7-jre is not available, but is referred to by another package.
fix: The following packages have unmet dependencies:
openjdk-7-jre : Depends: openjdk-7-jre-headless (= 7u51-2.4.6-1ubuntu4) but it is not going to be installed